### PR TITLE
Feature/48 fe use the backend endpoint to list roles

### DIFF
--- a/src/components/filters/FiltersContent.tsx
+++ b/src/components/filters/FiltersContent.tsx
@@ -5,7 +5,7 @@ const FiltersContent = () => {
   const [roles, setRoles] = useState([]);
 
   useEffect(() => {
-    axios.get("http://127.0.0.1:8000/student/list/for-home").then((response) => {
+    axios.get("https://itaperfils.eurecatacademy.org/api/v1/student/list/for-home").then((response) => {
       setRoles(response.data);
     })
     .catch((error) => {

--- a/src/components/filters/FiltersContent.tsx
+++ b/src/components/filters/FiltersContent.tsx
@@ -3,18 +3,21 @@ import { useEffect, useState } from "react";
 
 const FiltersContent = () => {
   const [students, setStudents] = useState([]);
+  const [roles, setRoles] = useState([]);
 
   useEffect(() => {
     axios.get("https://itaperfils.eurecatacademy.org/api/v1/specialization/list").then((response) => {
       setStudents(response.data);
+    });
+
+    axios.get("https://itaperfils.eurecatacademy.org/api/v1/specialization/list").then((response) => {
+      setRoles(response.data);
     })
     .catch((error) => {
       console.log(error);
     });
   }, []);
 
-  // Extraer todos los roles de todos los estudiantes
-  const roles = students.flatMap(student => student.tag.map(tag => tag.name));
 
   return (
     <>

--- a/src/components/filters/FiltersContent.tsx
+++ b/src/components/filters/FiltersContent.tsx
@@ -1,36 +1,51 @@
+import axios from "axios";
+import { useEffect, useState } from "react";
+
 const FiltersContent = () => {
+  const [roles, setRoles] = useState([]);
+
+  useEffect(() => {
+    axios.get("http://127.0.0.1:8000/student/list/for-home").then((response) => {
+      setRoles(response.data);
+    })
+    .catch((error) => {
+      console.log(error);
+    });
+  }, []);
   return (
     <>
       <h3 className="mb-7 w-40 text-2xl font-bold md:mb-14">Filtros</h3>
       <div>
         <h4 className="mb-2 font-bold">Roles</h4>
-        <label className="label cursor-pointer justify-start p-1">
+        {roles.map((roles, index) => (
+        <label key={index} className="label cursor-pointer justify-start p-1">
           <input
             type="checkbox"
             className="checkbox-primary checkbox mr-2 rounded-md border-2 border-gray-500"
           />
-          <span>Frontend</span>
+          <span>{roles}</span>
+        </label>
+        ))}
+        <label className="label cursor-pointer justify-start p-1">
+          <input
+            type="checkbox"
+            className="checkbox-primary  checkbox mr-2 rounded-md border-2 border-gray-500"
+          />
+          <span>{roles}</span>
         </label>
         <label className="label cursor-pointer justify-start p-1">
           <input
             type="checkbox"
             className="checkbox-primary  checkbox mr-2 rounded-md border-2 border-gray-500"
           />
-          <span>Backend</span>
+          <span>{roles}</span>
         </label>
         <label className="label cursor-pointer justify-start p-1">
           <input
             type="checkbox"
             className="checkbox-primary  checkbox mr-2 rounded-md border-2 border-gray-500"
           />
-          <span>Fullstack</span>
-        </label>
-        <label className="label cursor-pointer justify-start p-1">
-          <input
-            type="checkbox"
-            className="checkbox-primary  checkbox mr-2 rounded-md border-2 border-gray-500"
-          />
-          <span>Data Science</span>
+          <span>{roles}</span>
         </label>
       </div>
 

--- a/src/components/filters/FiltersContent.tsx
+++ b/src/components/filters/FiltersContent.tsx
@@ -34,6 +34,38 @@ const FiltersContent = () => {
           </label>
         ))}
       </div>
+      
+      <div>
+        <h4 className="mb-2 mt-4 font-bold">Desarrollo</h4>
+        <label className="label cursor-pointer justify-start p-1">
+          <input
+            type="checkbox"
+            className="checkbox-primary  checkbox mr-2 rounded-md border-2 border-gray-500"
+          />
+          <span>Spring</span>
+        </label>
+        <label className="label cursor-pointer justify-start p-1">
+          <input
+            type="checkbox"
+            className="checkbox-primary checkbox mr-2 rounded-md border-2 border-gray-500"
+          />
+          <span>Laravel</span>
+        </label>
+        <label className="label cursor-pointer justify-start p-1">
+          <input
+            type="checkbox"
+            className="checkbox-primary  checkbox mr-2 rounded-md border-2 border-gray-500"
+          />
+          <span>Angular</span>
+        </label>
+        <label className="label cursor-pointer justify-start p-1">
+          <input
+            type="checkbox"
+            className="checkbox-primary  checkbox mr-2 rounded-md border-2 border-gray-500"
+          />
+          <span>React</span>
+        </label>
+      </div>
     </>
   );
 };

--- a/src/components/filters/FiltersContent.tsx
+++ b/src/components/filters/FiltersContent.tsx
@@ -2,83 +2,34 @@ import axios from "axios";
 import { useEffect, useState } from "react";
 
 const FiltersContent = () => {
-  const [roles, setRoles] = useState([]);
+  const [students, setStudents] = useState([]);
 
   useEffect(() => {
     axios.get("https://itaperfils.eurecatacademy.org/api/v1/student/list/for-home").then((response) => {
-      setRoles(response.data);
+      setStudents(response.data);
     })
     .catch((error) => {
       console.log(error);
     });
   }, []);
+
+  // Extraer todos los roles de todos los estudiantes
+  const roles = students.flatMap(student => student.tags.map(tag => tag.name));
+
   return (
     <>
       <h3 className="mb-7 w-40 text-2xl font-bold md:mb-14">Filtros</h3>
       <div>
         <h4 className="mb-2 font-bold">Roles</h4>
-        {roles.map((roles, index) => (
-        <label key={index} className="label cursor-pointer justify-start p-1">
-          <input
-            type="checkbox"
-            className="checkbox-primary checkbox mr-2 rounded-md border-2 border-gray-500"
-          />
-          <span>{roles}</span>
-        </label>
+        {roles.map((role, index) => (
+          <label key={index} className="label cursor-pointer justify-start p-1">
+            <input
+              type="checkbox"
+              className="checkbox-primary checkbox mr-2 rounded-md border-2 border-gray-500"
+            />
+            <span>{role}</span>
+          </label>
         ))}
-        <label className="label cursor-pointer justify-start p-1">
-          <input
-            type="checkbox"
-            className="checkbox-primary  checkbox mr-2 rounded-md border-2 border-gray-500"
-          />
-          <span>{roles}</span>
-        </label>
-        <label className="label cursor-pointer justify-start p-1">
-          <input
-            type="checkbox"
-            className="checkbox-primary  checkbox mr-2 rounded-md border-2 border-gray-500"
-          />
-          <span>{roles}</span>
-        </label>
-        <label className="label cursor-pointer justify-start p-1">
-          <input
-            type="checkbox"
-            className="checkbox-primary  checkbox mr-2 rounded-md border-2 border-gray-500"
-          />
-          <span>{roles}</span>
-        </label>
-      </div>
-
-      <div>
-        <h4 className="mb-2 mt-4 font-bold">Desarrollo</h4>
-        <label className="label cursor-pointer justify-start p-1">
-          <input
-            type="checkbox"
-            className="checkbox-primary  checkbox mr-2 rounded-md border-2 border-gray-500"
-          />
-          <span>Spring</span>
-        </label>
-        <label className="label cursor-pointer justify-start p-1">
-          <input
-            type="checkbox"
-            className="checkbox-primary checkbox mr-2 rounded-md border-2 border-gray-500"
-          />
-          <span>Laravel</span>
-        </label>
-        <label className="label cursor-pointer justify-start p-1">
-          <input
-            type="checkbox"
-            className="checkbox-primary  checkbox mr-2 rounded-md border-2 border-gray-500"
-          />
-          <span>Angular</span>
-        </label>
-        <label className="label cursor-pointer justify-start p-1">
-          <input
-            type="checkbox"
-            className="checkbox-primary  checkbox mr-2 rounded-md border-2 border-gray-500"
-          />
-          <span>React</span>
-        </label>
       </div>
     </>
   );

--- a/src/components/filters/FiltersContent.tsx
+++ b/src/components/filters/FiltersContent.tsx
@@ -15,7 +15,6 @@ const FiltersContent = () => {
     });
   }, []);
 
-
   return (
     <>
       <h3 className="mb-7 w-40 text-2xl font-bold md:mb-14">Filtros</h3>

--- a/src/components/filters/FiltersContent.tsx
+++ b/src/components/filters/FiltersContent.tsx
@@ -5,7 +5,7 @@ const FiltersContent = () => {
   const [students, setStudents] = useState([]);
 
   useEffect(() => {
-    axios.get("https://itaperfils.eurecatacademy.org/api/v1/student/list/for-home").then((response) => {
+    axios.get("https://itaperfils.eurecatacademy.org/api/v1/specialization/list").then((response) => {
       setStudents(response.data);
     })
     .catch((error) => {
@@ -14,7 +14,7 @@ const FiltersContent = () => {
   }, []);
 
   // Extraer todos los roles de todos los estudiantes
-  const roles = students.flatMap(student => student.tags.map(tag => tag.name));
+  const roles = students.flatMap(student => student.tag.map(tag => tag.name));
 
   return (
     <>

--- a/src/components/filters/FiltersContent.tsx
+++ b/src/components/filters/FiltersContent.tsx
@@ -2,14 +2,11 @@ import axios from "axios";
 import { useEffect, useState } from "react";
 
 const FiltersContent = () => {
-  const [students, setStudents] = useState([]);
+
   const [roles, setRoles] = useState([]);
 
   useEffect(() => {
-    axios.get("https://itaperfils.eurecatacademy.org/api/v1/specialization/list").then((response) => {
-      setStudents(response.data);
-    });
-
+   
     axios.get("https://itaperfils.eurecatacademy.org/api/v1/specialization/list").then((response) => {
       setRoles(response.data);
     })


### PR DESCRIPTION
- [x] Conect rols with backend  

I have managed to connect with the new URL [https://itaperfils.eurecatacademy.org/api/v1/specialization/list](vscode-file://vscode-app/c:/Users/Usuari/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-sandbox/workbench/workbench.html) that I found in the documentation and which has finally worked. So now the 'roles' field is correctly connected with the backend and prints correctly.
![image](https://github.com/IT-Academy-BCN/ita-profiles-frontend/assets/123471637/fdf334f8-de9c-45cf-85e0-19bd911c167e)


