### PR TITLE
Feature/111-create-context-that-returns-student-UUID

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,14 +1,11 @@
 import SmallScreenProvider from './context/SmallScreenContext'
-import { SelectedStudentProvider } from './context/StudentIdContext'
 import Home from './pages/Home'
 import './styles/App.css'
 
 const App = () => (
-  <SelectedStudentProvider>
-    <SmallScreenProvider>
-      <Home />
-    </SmallScreenProvider>
-  </SelectedStudentProvider>
+  <SmallScreenProvider>
+    <Home />
+  </SmallScreenProvider>
 )
 
 export default App

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,11 +1,14 @@
 import SmallScreenProvider from './context/SmallScreenContext'
+import { SelectedStudentProvider } from './context/StudentIdContext'
 import Home from './pages/Home'
 import './styles/App.css'
 
 const App = () => (
-  <SmallScreenProvider>
-    <Home />
-  </SmallScreenProvider>
+  <SelectedStudentProvider>
+    <SmallScreenProvider>
+      <Home />
+    </SmallScreenProvider>
+  </SelectedStudentProvider>
 )
 
 export default App

--- a/src/__tests__/components/students/StudentCard.test.tsx
+++ b/src/__tests__/components/students/StudentCard.test.tsx
@@ -1,0 +1,30 @@
+import { render } from '@testing-library/react'
+import { Provider } from 'react-redux'
+import StudentCard from '../../../components/students/StudentCard'
+import { IStudentList } from '../../../interfaces/interfaces'
+import { store } from '../../../store/store'
+
+// We dont need to import anything like describe, it etc from vitest
+// We also dont need to import anything from react-testing-library
+// Kevin already setted it up so it doesnt become repetitive and you
+// Just do the tests...
+const mockStudentCard: IStudentList = {
+  id: 'abc123',
+  fullname: 'John',
+  subtitle: 'Doe',
+  photo: 'https://itaperfils.eurecatacademy.org/img/stud_2.png',
+  tags: [
+    { id: 1, name: 'react' },
+    { id: 2, name: 'php' },
+  ],
+}
+describe('StudentCard', () => {
+  it('should render the student card component', () => {
+    const { container } = render(
+      <Provider store={store}>
+        <StudentCard {...mockStudentCard} />
+      </Provider>,
+    )
+    expect(container).toBeInTheDocument()
+  })
+})

--- a/src/__tests__/components/students/StudentCard.test.tsx
+++ b/src/__tests__/components/students/StudentCard.test.tsx
@@ -1,13 +1,7 @@
 import { render } from '@testing-library/react'
-import { Provider } from 'react-redux'
 import StudentCard from '../../../components/students/StudentCard'
 import { IStudentList } from '../../../interfaces/interfaces'
-import { store } from '../../../store/store'
 
-// We dont need to import anything like describe, it etc from vitest
-// We also dont need to import anything from react-testing-library
-// Kevin already setted it up so it doesnt become repetitive and you
-// Just do the tests...
 const mockStudentCard: IStudentList = {
   id: 'abc123',
   fullname: 'John',
@@ -20,11 +14,7 @@ const mockStudentCard: IStudentList = {
 }
 describe('StudentCard', () => {
   it('should render the student card component', () => {
-    const { container } = render(
-      <Provider store={store}>
-        <StudentCard {...mockStudentCard} />
-      </Provider>,
-    )
+    const { container } = render(<StudentCard {...mockStudentCard} />)
     expect(container).toBeInTheDocument()
   })
 })

--- a/src/__tests__/components/students/StudentCard.test.tsx
+++ b/src/__tests__/components/students/StudentCard.test.tsx
@@ -1,20 +1,20 @@
-import { render } from '@testing-library/react'
-import StudentCard from '../../../components/students/StudentCard'
-import { IStudentList } from '../../../interfaces/interfaces'
+// import { render } from '@testing-library/react'
+// import StudentCard from '../../../components/students/StudentCard'
+// import { IStudentList } from '../../../interfaces/interfaces'
 
-const mockStudentCard: IStudentList = {
-  id: 'abc123',
-  fullname: 'John',
-  subtitle: 'Doe',
-  photo: 'https://itaperfils.eurecatacademy.org/img/stud_2.png',
-  tags: [
-    { id: 1, name: 'react' },
-    { id: 2, name: 'php' },
-  ],
-}
-describe('StudentCard', () => {
-  it('should render the student card component', () => {
-    const { container } = render(<StudentCard {...mockStudentCard} />)
-    expect(container).toBeInTheDocument()
-  })
-})
+// const mockStudentCard: IStudentList = {
+//   id: 'abc123',
+//   fullname: 'John',
+//   subtitle: 'Doe',
+//   photo: 'https://itaperfils.eurecatacademy.org/img/stud_2.png',
+//   tags: [
+//     { id: 1, name: 'react' },
+//     { id: 2, name: 'php' },
+//   ],
+// }
+// describe('StudentCard', () => {
+//   it('should render the student card component', () => {
+//     const { container } = render(<StudentCard {...mockStudentCard} />)
+//     expect(container).toBeInTheDocument()
+//   })
+// })

--- a/src/__tests__/components/students/StudentCard.test.tsx
+++ b/src/__tests__/components/students/StudentCard.test.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react'
+import { fireEvent, render } from '@testing-library/react'
 import { Provider } from 'react-redux'
 import StudentCard from '../../../components/students/StudentCard'
 import { IStudentList } from '../../../interfaces/interfaces'
@@ -14,6 +14,7 @@ const mockStudentCard: IStudentList = {
     { id: 2, name: 'php' },
   ],
 }
+
 describe('StudentCard', () => {
   it('should render the student card component', () => {
     const { container } = render(
@@ -22,5 +23,16 @@ describe('StudentCard', () => {
       </Provider>,
     )
     expect(container).toBeInTheDocument()
+  })
+  it('should trigger actions correctly on click', () => {
+    const { getByText } = render(
+      <Provider store={store}>
+        <StudentCard {...mockStudentCard} />
+      </Provider>,
+    )
+
+    fireEvent.click(getByText('John'))
+
+    expect(store.getState().ShowUserReducer.isUserPanelOpen).toBe(true)
   })
 })

--- a/src/__tests__/components/students/StudentCard.test.tsx
+++ b/src/__tests__/components/students/StudentCard.test.tsx
@@ -1,20 +1,26 @@
-// import { render } from '@testing-library/react'
-// import StudentCard from '../../../components/students/StudentCard'
-// import { IStudentList } from '../../../interfaces/interfaces'
+import { render } from '@testing-library/react'
+import { Provider } from 'react-redux'
+import StudentCard from '../../../components/students/StudentCard'
+import { IStudentList } from '../../../interfaces/interfaces'
+import { store } from '../../../store/store'
 
-// const mockStudentCard: IStudentList = {
-//   id: 'abc123',
-//   fullname: 'John',
-//   subtitle: 'Doe',
-//   photo: 'https://itaperfils.eurecatacademy.org/img/stud_2.png',
-//   tags: [
-//     { id: 1, name: 'react' },
-//     { id: 2, name: 'php' },
-//   ],
-// }
-// describe('StudentCard', () => {
-//   it('should render the student card component', () => {
-//     const { container } = render(<StudentCard {...mockStudentCard} />)
-//     expect(container).toBeInTheDocument()
-//   })
-// })
+const mockStudentCard: IStudentList = {
+  id: 'abc123',
+  fullname: 'John',
+  subtitle: 'Doe',
+  photo: 'https://itaperfils.eurecatacademy.org/img/stud_2.png',
+  tags: [
+    { id: 1, name: 'react' },
+    { id: 2, name: 'php' },
+  ],
+}
+describe('StudentCard', () => {
+  it('should render the student card component', () => {
+    const { container } = render(
+      <Provider store={store}>
+        <StudentCard {...mockStudentCard} />
+      </Provider>,
+    )
+    expect(container).toBeInTheDocument()
+  })
+})

--- a/src/__tests__/context/StudentIdContext.test.tsx
+++ b/src/__tests__/context/StudentIdContext.test.tsx
@@ -14,8 +14,17 @@ describe('SelectedStudentProvider', () => {
     const { result } = renderHook(() => useStudentIdContext(), { wrapper })
     expect(result.current.studentUUID)
   })
+  it('should throw an error', async () => {
+    renderHook(() => {
+      try {
+        useStudentIdContext()
+      } catch (error: unknown) {
+        if (error instanceof Error) {
+          expect(`${error.message}`).toEqual(
+            'useStudentIdContext has to be used inside a SelectedStudentProvider',
+          )
+        }
+      }
+    })
+  })
 })
-// describe('SelectedStudentIdContext', () => {
-// it('should return studentId when a card is selected', () => {})
-// it('should store studentId when a card is selected', () => {})
-// })

--- a/src/__tests__/context/StudentIdContext.test.tsx
+++ b/src/__tests__/context/StudentIdContext.test.tsx
@@ -1,0 +1,21 @@
+import { renderHook } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { TchildrenProps } from '../../interfaces/interfaces'
+import {
+  SelectedStudentProvider,
+  useStudentIdContext,
+} from '../../context/StudentIdContext'
+
+describe('SelectedStudentProvider', () => {
+  it('should render children', () => {
+    const wrapper = ({ children }: TchildrenProps) => (
+      <SelectedStudentProvider>{children}</SelectedStudentProvider>
+    )
+    const { result } = renderHook(() => useStudentIdContext(), { wrapper })
+    expect(result.current.studentUUID)
+  })
+})
+// describe('SelectedStudentIdContext', () => {
+// it('should return studentId when a card is selected', () => {})
+// it('should store studentId when a card is selected', () => {})
+// })

--- a/src/__tests__/context/StudentIdContext.test.tsx
+++ b/src/__tests__/context/StudentIdContext.test.tsx
@@ -12,7 +12,7 @@ describe('SelectedStudentProvider', () => {
       <SelectedStudentProvider>{children}</SelectedStudentProvider>
     )
     const { result } = renderHook(() => useStudentIdContext(), { wrapper })
-    expect(result.current.studentUUID)
+    expect(result.current.studentUUID).toBeDefined()
   })
   it('should throw an error', async () => {
     renderHook(() => {

--- a/src/components/students/StudentCard.tsx
+++ b/src/components/students/StudentCard.tsx
@@ -30,6 +30,7 @@ const StudentCard: React.FC<IStudentList> = ({
       onKeyDown={(e) => {
         if (e.key === 'Enter') {
           handleUserDetailToggler()
+          handleStudentSelect()
         }
       }}
     >

--- a/src/components/students/StudentCard.tsx
+++ b/src/components/students/StudentCard.tsx
@@ -1,24 +1,32 @@
 import { useAppDispatch } from '../../hooks/ReduxHooks'
 import { toggleUserPanel } from '../../store/reducers/getUserDetail/apiGetUserDetail'
 import { IStudentList } from '../../interfaces/interfaces'
+import { useStudentIdContext } from '../../context/StudentIdContext'
 
 const StudentCard: React.FC<IStudentList> = ({
   fullname,
   photo,
   subtitle,
   tags,
+  id,
 }) => {
   const dispatch = useAppDispatch()
+  const { setStudentUUID } = useStudentIdContext()
 
   const handleUserDetailToggler = () => {
     dispatch(toggleUserPanel())
   }
-
+  const handleStudentSelect = () => {
+    setStudentUUID(id)
+  }
   return (
     // eslint-disable-next-line jsx-a11y/no-static-element-interactions
     <div
       className="max-w-md flex cursor-pointer flex-col gap-3 rounded-2xl px-6 py-4 hover:bg-gray-4-base"
-      onClick={handleUserDetailToggler}
+      onClick={() => {
+        handleUserDetailToggler()
+        handleStudentSelect()
+      }}
       onKeyDown={(e) => {
         if (e.key === 'Enter') {
           handleUserDetailToggler()

--- a/src/context/StudentIdContext.tsx
+++ b/src/context/StudentIdContext.tsx
@@ -1,0 +1,41 @@
+import { createContext, useContext, useMemo, useState } from 'react'
+import { TchildrenProps } from '../interfaces/interfaces'
+
+type TSelectedStudentContext = {
+  // this can be null bc when the page loads, no student is selected.
+  studentUUID: string | null
+  setStudentUUID: (id: string | null) => void
+}
+// this context receives a state as argument:
+// studentUUID which is the one that will store the uuid
+// setStudentUUID which is the function that will get us the uuid
+export const SelectedStudentIdContext = createContext<TSelectedStudentContext>({
+  studentUUID: null,
+  setStudentUUID: () => {},
+})
+// The provider ===>
+export const SelectedStudentProvider = ({ children }: TchildrenProps) => {
+  const [studentUUID, setStudentUUID] = useState<string | null>(null)
+
+  const contextValue = useMemo(
+    () => ({ studentUUID, setStudentUUID }),
+    [studentUUID],
+  )
+
+  return (
+    <SelectedStudentIdContext.Provider value={contextValue}>
+      {children}
+    </SelectedStudentIdContext.Provider>
+  )
+}
+
+// hook to use context
+export const useStudentIdContext = () => {
+  const context = useContext(SelectedStudentIdContext)
+  if (!context) {
+    throw new Error(
+      'SelectedStudentIdContext has to be used inside a SelectedStudentProvider',
+    )
+  }
+  return context
+}

--- a/src/interfaces/interfaces.ts
+++ b/src/interfaces/interfaces.ts
@@ -20,11 +20,11 @@ export type TSmallScreenContext = {
 
 // === studentList ===
 export interface IStudentList {
+  id: string
   fullname: string
   subtitle: string
   photo: string
   tags: ITag[]
-  id: number
 }
 
 export interface ITag {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,19 +1,22 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
-import { Provider } from 'react-redux'
 import { I18nextProvider } from 'react-i18next'
+import { Provider } from 'react-redux'
+import { SelectedStudentProvider } from './context/StudentIdContext'
 import App from './App'
 import i18n from './locales/i18n'
 import { store } from './store/store'
 
-import './styles/normalize.css'
 import './styles/index.css'
+import './styles/normalize.css'
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <Provider store={store}>
       <I18nextProvider i18n={i18n}>
-        <App />
+        <SelectedStudentProvider>
+          <App />
+        </SelectedStudentProvider>
       </I18nextProvider>
     </Provider>
   </React.StrictMode>,


### PR DESCRIPTION
To use this context, we must use the `useStudentIdContext` custom hook.
To do so we import it to the file where we're gonna use it and then we destructure it to obtain the `studentUUID`. You can also get `setStudentUUID`. Like so:

`const {studentUUID} = useStudentIdContext()` 

We should pass this object that has the student uuid to the endpoint.